### PR TITLE
fix tests (travis)

### DIFF
--- a/rapidjson.cpp
+++ b/rapidjson.cpp
@@ -183,16 +183,16 @@ PHP_METHOD(rapidjson, offsetSet) /* {{{ */ {
 
 	obj = zend_read_property(rapidjson_ce, self, ZEND_STRL("obj"), 1, NULL);
 	Document *document;
-    document = (Document *)obj->value.ptr;
+	document = (Document *)obj->value.ptr;
 	
 	if (!document->HasMember(key->val)) {
 		RETURN_NULL();
 		return;	
 	}
-	Value& val = (*document)[key->val]; 
-	
+	Value& val = (*document)[key->val];
+
 	if (IS_STRING == Z_TYPE_P(value)) {
-		val.SetString(StringRef(Z_STRVAL_P(value), Z_STRLEN_P(value)));
+		val.SetString(Z_STRVAL_P(value), Z_STRLEN_P(value));
 	} else if (IS_LONG == Z_TYPE_P(value)) {
 		val.SetInt64(Z_LVAL_P(value));
 	} else if (IS_NULL == Z_TYPE_P(value)) {

--- a/tests/001.phpt
+++ b/tests/001.phpt
@@ -7,9 +7,9 @@ Check for rapidjson get value and toString
 $str = '{"author":"Jason Young"}';
 $obj = new Rapidjson($str);
 echo $obj;
+echo "\n";
 var_dump($obj['author']);
 ?>
 --EXPECT--
-{
-    "author": "Jason Young"
-}string(11) "Jason Young"
+{"author":"Jason Young"}
+string(11) "Jason Young"

--- a/tests/002.phpt
+++ b/tests/002.phpt
@@ -11,6 +11,4 @@ echo $obj;
 ?>
 --EXPECT--
 string(11) "Jason Young"
-{
-    "author": "Jason Young"
-}
+{"author":"Jason Young"}

--- a/tests/003.phpt
+++ b/tests/003.phpt
@@ -11,15 +11,20 @@ $obj->parse($str);
 var_dump($obj['author']);
 $obj['author'] = "Yangshengjie";
 var_dump($obj['author']);
+echo $obj;
+echo "\n";
 
 var_dump($obj['age']);
-$obj['age'] = "23";
+$obj['age'] = 24;
 var_dump($obj['age']);
+echo $obj;
+echo "\n";
 
 ?>
 --EXPECT--
 string(11) "Jason Young"
 string(12) "Yangshengjie"
+{"author":"Yangshengjie","age":23}
 int(23)
-string(2) "23"
-
+int(24)
+{"author":"Yangshengjie","age":24}


### PR DESCRIPTION
Tried to fix all tests, but I cannot discover the error in test 003. There is variable shared that is causing the method name to end up in the json structure. I have no idea how to fix it. Had multiple tries, but all failed. Lack of C knowledge.

But my guess is it has something to do with the `offsetSet` method. More specifically with replacing [a string](https://github.com/frederikbosch/php-rapidjson/blob/master/rapidjson.cpp#L195) because it seems not the case with [integers](https://travis-ci.org/RustJason/php-rapidjson/builds/96556647#L296). I guess we should not use `StringRef` but something like `ZVAL_COPY_VALUE`.
